### PR TITLE
Modify QueryOption, RetryPolicy and refactoring code

### DIFF
--- a/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraModule.java
+++ b/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraModule.java
@@ -10,26 +10,33 @@ import java.util.List;
  */
 public class CassandraModule extends ConfigurableModule<CassandraModule.Config> {
 
-	public static class Config {
+	@Override
+	protected void configure() {
+		bind(CassandraService.class).in(Scopes.SINGLETON);
+		bind(CassandraHealthCheck.class).in(Scopes.SINGLETON);
+		bind(CustomRetryPolicy.class).in(Scopes.SINGLETON);
+	}
 
-		public Config() {
-		}
+	public static class Config {
 
 		JKSConfig truststore;
 		JKSConfig keystore;
-
 		String user;
 		String password;
-
 		String keyspace;
 		String validationQuery = "SELECT * FROM system.schema_keyspaces";
-
 		Boolean shareEventLoopGroup = false;
-
 		String migrationFile = "/migrations/cql.changelog";
 		Boolean autoMigrate = false;
-
 		List<String> seeds;
+		int protocolVersion = 2;
+		int readTimeoutMillis = 5000;
+		int defaultConsistencyLevel = 6;
+		boolean defaultIdempotence = false;
+		boolean retryQuery = false;
+
+		public Config() {
+		}
 
 		public JKSConfig getTruststore() {
 			return truststore;
@@ -111,6 +118,46 @@ public class CassandraModule extends ConfigurableModule<CassandraModule.Config> 
 			this.autoMigrate = autoMigrate;
 		}
 
+		public int getProtocolVersion() {
+			return protocolVersion;
+		}
+
+		public void setProtocolVersion(int protocolVersion) {
+			this.protocolVersion = protocolVersion;
+		}
+
+		public int getReadTimeoutMillis() {
+			return readTimeoutMillis;
+		}
+
+		public void setReadTimeoutMillis(int readTimeoutMillis) {
+			this.readTimeoutMillis = readTimeoutMillis;
+		}
+
+		public int getDefaultConsistencyLevel() {
+			return defaultConsistencyLevel;
+		}
+
+		public void setDefaultConsistencyLevel(int defaultConsistencyLevel) {
+			this.defaultConsistencyLevel = defaultConsistencyLevel;
+		}
+
+		public boolean getDefaultIdempotence() {
+			return defaultIdempotence;
+		}
+
+		public void setDefaultIdempotence(boolean defaultIdempotence) {
+			this.defaultIdempotence = defaultIdempotence;
+		}
+
+		public boolean getRetryQuery() {
+			return retryQuery;
+		}
+
+		public void setRetryQuery(boolean retryQuery) {
+			this.retryQuery = retryQuery;
+		}
+
 		public static class JKSConfig {
 
 			String path;
@@ -135,12 +182,6 @@ public class CassandraModule extends ConfigurableModule<CassandraModule.Config> 
 				this.password = password;
 			}
 		}
-	}
-
-	@Override
-	protected void configure() {
-		bind(CassandraService.class).in(Scopes.SINGLETON);
-		bind(CassandraHealthCheck.class).in(Scopes.SINGLETON);
 	}
 
 }

--- a/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraModule.java
+++ b/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraModule.java
@@ -31,7 +31,7 @@ public class CassandraModule extends ConfigurableModule<CassandraModule.Config> 
 		List<String> seeds;
 		int protocolVersion = 2;
 		int readTimeoutMillis = 5000;
-		int defaultConsistencyLevel = 6;
+		int defaultConsistencyLevel = 0;
 		boolean defaultIdempotence = false;
 		boolean retryQuery = false;
 

--- a/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraModule.java
+++ b/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraModule.java
@@ -14,7 +14,7 @@ public class CassandraModule extends ConfigurableModule<CassandraModule.Config> 
 	protected void configure() {
 		bind(CassandraService.class).in(Scopes.SINGLETON);
 		bind(CassandraHealthCheck.class).in(Scopes.SINGLETON);
-		bind(CustomRetryPolicy.class).in(Scopes.SINGLETON);
+		bind(FixedRetryPolicy.class).in(Scopes.SINGLETON);
 	}
 
 	public static class Config {

--- a/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraModule.java
+++ b/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraModule.java
@@ -29,11 +29,10 @@ public class CassandraModule extends ConfigurableModule<CassandraModule.Config> 
 		String migrationFile = "/migrations/cql.changelog";
 		Boolean autoMigrate = false;
 		List<String> seeds;
-		int protocolVersion = 2;
+		int protocolVersion = -1;
 		int readTimeoutMillis = 5000;
-		int defaultConsistencyLevel = 0;
+		int defaultConsistencyLevel = -1;
 		boolean defaultIdempotence = false;
-		boolean retryQuery = false;
 
 		public Config() {
 		}
@@ -148,14 +147,6 @@ public class CassandraModule extends ConfigurableModule<CassandraModule.Config> 
 
 		public void setDefaultIdempotence(boolean defaultIdempotence) {
 			this.defaultIdempotence = defaultIdempotence;
-		}
-
-		public boolean getRetryQuery() {
-			return retryQuery;
-		}
-
-		public void setRetryQuery(boolean retryQuery) {
-			this.retryQuery = retryQuery;
 		}
 
 		public static class JKSConfig {

--- a/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraService.java
+++ b/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraService.java
@@ -23,13 +23,13 @@ import java.security.SecureRandom;
 public class CassandraService implements Service {
 	private final String[] cipherSuites = new String[]{"TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"};
 	private final CassandraModule.Config cassandraConfig;
-	private final CustomRetryPolicy customRetryPolicy;
+	private final FixedRetryPolicy customRetryPolicy;
 	protected Cluster cluster;
 	protected Session session;
 	private Logger logger = LoggerFactory.getLogger(CassandraService.class);
 
 	@Inject
-	public CassandraService(CassandraModule.Config cassandraConfig, CustomRetryPolicy customRetryPolicy) {
+	public CassandraService(CassandraModule.Config cassandraConfig, FixedRetryPolicy customRetryPolicy) {
 		this.cassandraConfig = cassandraConfig;
 		this.customRetryPolicy = customRetryPolicy;
 	}

--- a/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CustomRetryPolicy.java
+++ b/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CustomRetryPolicy.java
@@ -1,0 +1,63 @@
+package smartthings.ratpack.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.WriteType;
+import com.datastax.driver.core.exceptions.DriverException;
+import com.datastax.driver.core.policies.RetryPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CustomRetryPolicy implements RetryPolicy {
+	private int retryCount = 3;
+
+	private Logger logger = LoggerFactory.getLogger(CustomRetryPolicy.class);
+
+	@Override
+	public RetryDecision onReadTimeout(Statement stmnt, ConsistencyLevel cl, int requiredResponses, int receivedResponses, boolean dataReceived, int nbRetry) {
+		logger.warn("[CustomRetryPolicy]-onReadTimeout(), requiredResponses={}, receivedResponses={}, dataReceived={}, nbRetry={}", requiredResponses, receivedResponses, dataReceived, nbRetry);
+		if (dataReceived) {
+			return RetryDecision.ignore();
+		} else if (nbRetry < retryCount) {
+			return RetryDecision.retry(cl);
+		} else {
+			return RetryDecision.rethrow();
+		}
+	}
+
+	@Override
+	public RetryDecision onWriteTimeout(Statement stmnt, ConsistencyLevel cl, WriteType wt, int requiredResponses, int receivedResponses, int nbRetry) {
+		logger.warn("[CustomRetryPolicy]-onWriteTimeout(), requiredResponses={}, receivedResponses={}, nbRetry={}", requiredResponses, receivedResponses, nbRetry);
+		if (nbRetry < retryCount) {
+			return RetryDecision.retry(cl);
+		}
+		return RetryDecision.rethrow();
+	}
+
+	@Override
+	public RetryDecision onUnavailable(Statement stmnt, ConsistencyLevel cl, int requiredResponses, int receivedResponses, int nbRetry) {
+		logger.warn("[CustomRetryPolicy]-onUnavailable(), requiredResponses={}, receivedResponses={}, nbRetry={}", requiredResponses, receivedResponses, nbRetry);
+		if (nbRetry < retryCount) {
+			return RetryDecision.tryNextHost(cl);
+		}
+		return RetryDecision.rethrow();
+	}
+
+	@Override
+	public RetryDecision onRequestError(Statement statement, ConsistencyLevel cl, DriverException e, int nbRetry) {
+		logger.warn("[CustomRetryPolicy]-onRequestError(), nbRetry={}", nbRetry);
+		if (nbRetry < retryCount) {
+			return RetryDecision.tryNextHost(cl);
+		}
+		return RetryDecision.rethrow();
+	}
+
+	@Override
+	public void init(Cluster cluster) {
+	}
+
+	@Override
+	public void close() {
+	}
+}

--- a/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/FixedRetryPolicy.java
+++ b/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/FixedRetryPolicy.java
@@ -9,10 +9,14 @@ import com.datastax.driver.core.policies.RetryPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CustomRetryPolicy implements RetryPolicy {
+/**
+ * A policy that defines a default behavior to adopt when a request fails.
+ * Difference of existing DefaultRetryPolicy is that use Client side retry count variable only. and available retry count fixed 3 times.
+ */
+public class FixedRetryPolicy implements RetryPolicy {
 	private int retryCount = 3;
 
-	private Logger logger = LoggerFactory.getLogger(CustomRetryPolicy.class);
+	private Logger logger = LoggerFactory.getLogger(FixedRetryPolicy.class);
 
 	@Override
 	public RetryDecision onReadTimeout(Statement stmnt, ConsistencyLevel cl, int requiredResponses, int receivedResponses, boolean dataReceived, int nbRetry) {

--- a/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/FixedRetryPolicy.java
+++ b/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/FixedRetryPolicy.java
@@ -20,7 +20,7 @@ public class FixedRetryPolicy implements RetryPolicy {
 
 	@Override
 	public RetryDecision onReadTimeout(Statement stmnt, ConsistencyLevel cl, int requiredResponses, int receivedResponses, boolean dataReceived, int nbRetry) {
-		logger.warn("[CustomRetryPolicy]-onReadTimeout(), requiredResponses={}, receivedResponses={}, dataReceived={}, nbRetry={}", requiredResponses, receivedResponses, dataReceived, nbRetry);
+		logger.warn("onReadTimeout(), requiredResponses={}, receivedResponses={}, dataReceived={}, nbRetry={}", requiredResponses, receivedResponses, dataReceived, nbRetry);
 		if (dataReceived) {
 			return RetryDecision.ignore();
 		} else if (nbRetry < retryCount) {
@@ -32,16 +32,16 @@ public class FixedRetryPolicy implements RetryPolicy {
 
 	@Override
 	public RetryDecision onWriteTimeout(Statement stmnt, ConsistencyLevel cl, WriteType wt, int requiredResponses, int receivedResponses, int nbRetry) {
-		logger.warn("[CustomRetryPolicy]-onWriteTimeout(), requiredResponses={}, receivedResponses={}, nbRetry={}", requiredResponses, receivedResponses, nbRetry);
+		logger.warn("-onWriteTimeout(), requiredResponses={}, receivedResponses={}, nbRetry={}", requiredResponses, receivedResponses, nbRetry);
 		if (nbRetry < retryCount) {
-			return RetryDecision.retry(cl);
+			return wt == WriteType.BATCH_LOG ? RetryDecision.retry(cl) : RetryDecision.rethrow();
 		}
 		return RetryDecision.rethrow();
 	}
 
 	@Override
 	public RetryDecision onUnavailable(Statement stmnt, ConsistencyLevel cl, int requiredResponses, int receivedResponses, int nbRetry) {
-		logger.warn("[CustomRetryPolicy]-onUnavailable(), requiredResponses={}, receivedResponses={}, nbRetry={}", requiredResponses, receivedResponses, nbRetry);
+		logger.warn("onUnavailable(), requiredResponses={}, receivedResponses={}, nbRetry={}", requiredResponses, receivedResponses, nbRetry);
 		if (nbRetry < retryCount) {
 			return RetryDecision.tryNextHost(cl);
 		}
@@ -50,7 +50,7 @@ public class FixedRetryPolicy implements RetryPolicy {
 
 	@Override
 	public RetryDecision onRequestError(Statement statement, ConsistencyLevel cl, DriverException e, int nbRetry) {
-		logger.warn("[CustomRetryPolicy]-onRequestError(), nbRetry={}", nbRetry);
+		logger.warn("onRequestError(), nbRetry={}", nbRetry);
 		if (nbRetry < retryCount) {
 			return RetryDecision.tryNextHost(cl);
 		}

--- a/ratpack-cassandra/src/test/groovy/smartthings/ratpack/cassandra/CassandraServiceSpec.groovy
+++ b/ratpack-cassandra/src/test/groovy/smartthings/ratpack/cassandra/CassandraServiceSpec.groovy
@@ -6,10 +6,10 @@ import org.cassandraunit.dataset.CQLDataSet
 import org.cassandraunit.dataset.cql.ClassPathCQLDataSet
 import ratpack.registry.Registry
 import ratpack.service.StartEvent
+import ratpack.test.exec.ExecHarness
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
-import ratpack.test.exec.ExecHarness
 
 class CassandraServiceSpec extends Specification {
 
@@ -39,11 +39,12 @@ class CassandraServiceSpec extends Specification {
 		CassandraModule.Config cassConfig = new CassandraModule.Config()
 		cassConfig.setKeyspace(TEST_KEYSPACE)
 		cassConfig.setSeeds([TEST_SEED])
+		CustomRetryPolicy customRetryPolicy = new CustomRetryPolicy();
 		CassandraService service
 
 		when:
 		harness.run {
-			service = new CassandraService(cassConfig)
+			service = new CassandraService(cassConfig, customRetryPolicy)
 			service.onStart(new StartEvent() {
 				@Override
 				Registry getRegistry() {
@@ -66,11 +67,12 @@ class CassandraServiceSpec extends Specification {
 		CassandraModule.Config cassConfig = new CassandraModule.Config()
 		cassConfig.setKeyspace(TEST_KEYSPACE)
 		cassConfig.setSeeds(["localhost:1111"])
+		CustomRetryPolicy customRetryPolicy = new CustomRetryPolicy();
 		CassandraService service
 
 		when:
 		harness.run {
-			service = new CassandraService(cassConfig)
+			service = new CassandraService(cassConfig, customRetryPolicy)
 			service.onStart(new StartEvent() {
 				@Override
 				Registry getRegistry() {


### PR DESCRIPTION
1. Add the QueryOption for the statement's retry policy
  - Set the readTimeout for reducing read time if readTime over the value then the statement retry again
  - Set the defaultIdempotence for statement's retry policy (default is false it will does not working)
 
2. Add the CustomRetryPolicy
  - it will work to retry 3 times
 
3. Add the DefaultConsistencyLevel for result resond correctly 
  -  Set to LOCAL_QUORUM from ONE

4. Code refactoring for extending subclass
  - Existing function and variables are private so it can not use builder object