### PR TITLE
BEE-1791: ValidationQuery per CassandraVersion

### DIFF
--- a/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraHealthCheck.java
+++ b/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraHealthCheck.java
@@ -1,5 +1,6 @@
 package smartthings.ratpack.cassandra;
 
+import com.datastax.driver.core.Host;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,13 +10,12 @@ import ratpack.registry.Registry;
 
 public class CassandraHealthCheck implements HealthCheck {
 	private final CassandraService cassandraService;
-	private final String validationQuery;
+	private String validationQuery;
 
 	Logger logger = LoggerFactory.getLogger(CassandraHealthCheck.class);
 
 	@Inject
-	public CassandraHealthCheck(CassandraModule.Config cassandraConfig, CassandraService cassandraService) {
-		this.validationQuery = cassandraConfig.getValidationQuery();
+	public CassandraHealthCheck(CassandraService cassandraService) {
 		this.cassandraService = cassandraService;
 	}
 
@@ -28,6 +28,13 @@ public class CassandraHealthCheck implements HealthCheck {
 	public Promise<Result> check(Registry registry) throws Exception {
 		return Promise.async(upstream -> {
 			try {
+				Host host = cassandraService.getSession().getState().getConnectedHosts().iterator().next();
+				if (host.getCassandraVersion().getMajor() == 3) {
+					this.validationQuery = "SELECT * FROM system_schema.keyspaces";
+				} else if (host.getCassandraVersion().getMajor() == 2) {
+					this.validationQuery = "SELECT * FROM system.schema_keyspaces";
+				}
+
 				cassandraService.getSession().execute(validationQuery);
 				upstream.success(Result.healthy());
 			} catch (Exception ex) {

--- a/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraModule.java
+++ b/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraModule.java
@@ -22,7 +22,6 @@ public class CassandraModule extends ConfigurableModule<CassandraModule.Config> 
 		String password;
 
 		String keyspace;
-		String validationQuery = "SELECT * FROM system.schema_keyspaces";
 
 		Boolean shareEventLoopGroup = false;
 
@@ -77,14 +76,6 @@ public class CassandraModule extends ConfigurableModule<CassandraModule.Config> 
 
 		public void setSeeds(List<String> seeds) {
 			this.seeds = seeds;
-		}
-
-		public String getValidationQuery() {
-			return validationQuery;
-		}
-
-		public void setValidationQuery(String validationQuery) {
-			this.validationQuery = validationQuery;
 		}
 
 		public Boolean getShareEventLoopGroup() {


### PR DESCRIPTION
Adds additional logic to check connected host version and uses an appropriate validation query for Cassandra v2 or v3.

v3 = `"SELECT * FROM system_schema.keyspaces"`
v2 = `"SELECT * FROM system.schema_keyspaces"`