### PR TITLE
[BEE-3985] Make UsedHostsPerRemoteDc Configurable

### DIFF
--- a/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraModule.java
+++ b/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraModule.java
@@ -36,6 +36,8 @@ public class CassandraModule extends ConfigurableModule<CassandraModule.Config> 
 
 		List<String> seeds;
 
+		int remoteHostsPerDc = 1;
+
 
 		public JKSConfig getTruststore() {
 			return truststore;
@@ -131,6 +133,12 @@ public class CassandraModule extends ConfigurableModule<CassandraModule.Config> 
 
 		public void setMaxSpeculativeExecutions(int maxSpeculativeExecutions) {
 			this.maxSpeculativeExecutions = maxSpeculativeExecutions;
+		}
+
+		public int getRemoteHostsPerDc() { return remoteHostsPerDc; }
+
+		public void setRemoteHostsPerDc(int remoteHostsPerDc) {
+			this.remoteHostsPerDc = remoteHostsPerDc;
 		}
 
 		public static class JKSConfig {

--- a/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraService.java
+++ b/ratpack-cassandra/src/main/java/smartthings/ratpack/cassandra/CassandraService.java
@@ -38,7 +38,7 @@ public class CassandraService implements Service {
 		//Set the highest tracking to just above the socket timeout for the read.
 		PerHostPercentileTracker tracker = PerHostPercentileTracker.builder(SocketOptions.DEFAULT_READ_TIMEOUT_MILLIS + 500).build();
 
-		DCAwareRoundRobinPolicy dcAwareRoundRobinPolicy = DCAwareRoundRobinPolicy.builder().withUsedHostsPerRemoteDc(1).build();
+		DCAwareRoundRobinPolicy dcAwareRoundRobinPolicy = DCAwareRoundRobinPolicy.builder().withUsedHostsPerRemoteDc(cassandraConfig.getRemoteHostsPerDc()).build();
 
 		Cluster.Builder builder = Cluster.builder()
 				.withLoadBalancingPolicy(new TokenAwarePolicy(dcAwareRoundRobinPolicy));


### PR DESCRIPTION
This change is required to support migration of DCs. The service using this project would continue to keep an open connection to the old DC preventing it from being taken down. We need the ability to set this value to 0 to allow for the migration to take place.

[https://docs.datastax.com/en/drivers/java/3.6/com/datastax/driver/core/policies/DCAwareRoundRobinPolicy.Builder.html#withUsedHostsPerRemoteDc-int-](https://docs.datastax.com/en/drivers/java/3.6/com/datastax/driver/core/policies/DCAwareRoundRobinPolicy.Builder.html#withUsedHostsPerRemoteDc-int-)