### PR TITLE
Use Java11 for container.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,10 @@ jobs:
     <<: *defaults
 
     steps:
+      - run:
+          name: Set java version
+          command: sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
@@ -32,6 +36,10 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/repo
+
+      - run:
+          name: Set java version
+          command: sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
 
       - run:
           name: Gradle Check and Coverage


### PR DESCRIPTION
It appears that using Java 17 (which is what the docker container defaults to) breaks some of the tests with the following error:
```java
<failure message="java.lang.NoClassDefFoundError: Could not initialize class io.netty.util.internal.PlatformDependent0" type="java.lang.NoClassDefFoundError">java.lang.NoClassDefFoundError: Could not initialize class io.netty.util.internal.PlatformDependent0
        at io.netty.util.internal.PlatformDependent.&lt;clinit&gt;(PlatformDependent.java:101)
        at io.netty.util.ConstantPool.&lt;init&gt;(ConstantPool.java:32)
        at io.netty.util.Signal$1.&lt;init&gt;(Signal.java:27)
        at io.netty.util.Signal.&lt;clinit&gt;(Signal.java:27)
        at io.netty.util.concurrent.DefaultPromise.&lt;clinit&gt;(DefaultPromise.java:42)
        at io.netty.util.concurrent.GlobalEventExecutor.&lt;init&gt;(GlobalEventExecutor.java:44)
        at io.netty.util.concurrent.GlobalEventExecutor.&lt;clinit&gt;(GlobalEventExecutor.java:41)
        at com.datastax.driver.core.Connection$Factory.&lt;init&gt;(Connection.java:969)
        at com.datastax.driver.core.Cluster$Manager.init(Cluster.java:1665)
        at com.datastax.driver.core.Cluster.init(Cluster.java:214)
        at com.datastax.driver.core.Cluster.connectAsync(Cluster.java:387)
        at com.datastax.driver.core.Cluster.connectAsync(Cluster.java:366)
        at com.datastax.driver.core.Cluster.connect(Cluster.java:311)
        at smartthings.ratpack.cassandra.CassandraServiceSpec.setupSpec(CassandraServiceSpec.groovy:31)
</failure>
```